### PR TITLE
change PATH in server tests to prefer blib/script over bin

### DIFF
--- a/t/91_start.t
+++ b/t/91_start.t
@@ -11,7 +11,7 @@ is($#unusedports, 2, "get unused port") or done_mytest();
 my ($mainport, $workport, $resolveport) = @unusedports;
 
 my $commonopt = "--cachedir '$tmpdir' --port1 $mainport --port2 $workport --port3 $resolveport";
-my $addpath = "PATH=$FindBin::Bin/../bin:\${PATH} ; export PATH";
+my $addpath = "PATH=$FindBin::Bin/../blib/script:$FindBin::Bin/../bin:\${PATH} ; export PATH";
 my ($stat, $mainstat, $workstat, $resolvestat);
 
 system "$addpath ; plsense $commonopt svstart > /dev/null";

--- a/t/92_config.t
+++ b/t/92_config.t
@@ -20,7 +20,7 @@ if ( -f $confpath ) {
     ok(unlink($confpath), "init config") or done_mytest();
 }
 
-my $addpath = "PATH=$FindBin::Bin/../bin:\${PATH} ; export PATH";
+my $addpath = "PATH=$FindBin::Bin/../blib/script:$FindBin::Bin/../bin:\${PATH} ; export PATH";
 my $chhome = "HOME=$workpath ; export HOME";
 
 # cancel


### PR DESCRIPTION
Running the tests under a perlbrew environment may fail because the
system perl does not have the requisite features/modules installed. The
tests should normally be run after blib has been populated and so
putting that in front of the PATH in these tests ensures the right
interpreter is used.

My earlier PR some months ago took the wrong approach to fixing this. Thanks for responding to that, sorry it took so long to get back to you.
